### PR TITLE
add rbp namespace + std import in cpp

### DIFF
--- a/GuillotineBinPack.cpp
+++ b/GuillotineBinPack.cpp
@@ -15,6 +15,8 @@
 
 #include "GuillotineBinPack.h"
 
+namespace rbp {
+
 using namespace std;
 
 GuillotineBinPack::GuillotineBinPack()
@@ -633,4 +635,6 @@ void GuillotineBinPack::MergeFreeList()
 	for(size_t i = 0; i < freeRectangles.size(); ++i)
 		assert(test.Add(freeRectangles[i]) == true);
 #endif
+}
+
 }

--- a/GuillotineBinPack.h
+++ b/GuillotineBinPack.h
@@ -11,6 +11,8 @@
 
 #include "Rect.h"
 
+namespace rbp {
+
 /** GuillotineBinPack implements different variants of bin packer algorithms that use the GUILLOTINE data structure
 	to keep track of the free space of the bin where rectangles may be placed. */
 class GuillotineBinPack
@@ -128,3 +130,5 @@ private:
 	/// Splits the given L-shaped free rectangle into two new free rectangles along the given fixed split axis.
 	void SplitFreeRectAlongAxis(const Rect &freeRect, const Rect &placedRect, bool splitHorizontal);
 };
+
+}

--- a/MaxRectsBinPack.cpp
+++ b/MaxRectsBinPack.cpp
@@ -15,6 +15,8 @@
 
 #include "MaxRectsBinPack.h"
 
+namespace rbp {
+
 using namespace std;
 
 MaxRectsBinPack::MaxRectsBinPack()
@@ -510,4 +512,6 @@ void MaxRectsBinPack::PruneFreeList()
 				--j;
 			}
 		}
+}
+
 }

--- a/MaxRectsBinPack.h
+++ b/MaxRectsBinPack.h
@@ -11,6 +11,8 @@
 
 #include "Rect.h"
 
+namespace rbp {
+
 /** MaxRectsBinPack implements the MAXRECTS data structure and different bin packing algorithms that 
 	use this structure. */
 class MaxRectsBinPack
@@ -79,3 +81,5 @@ private:
 	/// Goes through the free rectangle list and removes any redundant entries.
 	void PruneFreeList();
 };
+
+}

--- a/MaxRectsBinPackTest/BinPack.cpp
+++ b/MaxRectsBinPackTest/BinPack.cpp
@@ -2,6 +2,7 @@
 
 int main(int argc, char **argv)
 {
+	
 	if (argc < 5 || argc % 2 != 1)
 	{
 		printf("Usage: MaxRectsBinPackTest binWidth binHeight w_0 h_0 w_1 h_1 w_2 h_2 ... w_n h_n\n");
@@ -10,7 +11,9 @@ int main(int argc, char **argv)
 		printf("Example: MaxRectsBinPackTest 256 256 30 20 50 20 10 80 90 20\n");
 		return 0;
 	}
-
+	
+	using namespace rbp;
+	
 	// Create a bin to pack to, use the bin size from command line.
 	MaxRectsBinPack bin;
 	int binWidth = atoi(argv[1]);

--- a/Rect.cpp
+++ b/Rect.cpp
@@ -7,6 +7,8 @@
 
 #include "Rect.h"
 
+namespace rbp {
+
 /*
 #include "clb/Algorithm/Sort.h"
 
@@ -44,4 +46,6 @@ bool IsContainedIn(const Rect &a, const Rect &b)
 	return a.x >= b.x && a.y >= b.y 
 		&& a.x+a.width <= b.x+b.width 
 		&& a.y+a.height <= b.y+b.height;
+}
+
 }

--- a/Rect.h
+++ b/Rect.h
@@ -15,7 +15,9 @@
 #define debug_assert(x)
 #endif
 
-using namespace std;
+//using namespace std;
+
+namespace rbp {
 
 struct RectSize
 {
@@ -87,3 +89,5 @@ public:
 		return false;
 	}
 };
+
+}

--- a/ShelfBinPack.cpp
+++ b/ShelfBinPack.cpp
@@ -13,6 +13,8 @@
 
 #include "ShelfBinPack.h"
 
+namespace rbp {
+
 using namespace std;
 
 ShelfBinPack::ShelfBinPack()
@@ -390,4 +392,6 @@ void ShelfBinPack::MoveShelfToWasteMap(Shelf &shelf)
 float ShelfBinPack::Occupancy() const
 {
 	return (float)usedSurfaceArea / (binWidth * binHeight);
+}
+
 }

--- a/ShelfBinPack.h
+++ b/ShelfBinPack.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+namespace rbp {
+
 /** ShelfBinPack implements different bin packing algorithms that use the SHELF data structure. ShelfBinPack
 also uses GuillotineBinPack for the waste map if it is enabled. */
 class ShelfBinPack
@@ -101,3 +103,5 @@ private:
 	/// Creates a new shelf of the given starting height, which will become the topmost 'open' shelf.
 	void StartNewShelf(int startingHeight);
 };
+
+}

--- a/ShelfNextFitBinPack.cpp
+++ b/ShelfNextFitBinPack.cpp
@@ -17,6 +17,8 @@
 
 #include "ShelfNextFitBinPack.h"
 
+namespace rbp {
+
 using namespace std;
 
 void ShelfNextFitBinPack::Init(int width, int height)
@@ -96,4 +98,6 @@ ShelfNextFitBinPack::Node ShelfNextFitBinPack::Insert(int width, int height)
 float ShelfNextFitBinPack::Occupancy() const
 {
 	return (float)usedSurfaceArea / (binWidth * binHeight);
+}
+
 }

--- a/ShelfNextFitBinPack.h
+++ b/ShelfNextFitBinPack.h
@@ -13,6 +13,8 @@
 
 #include <vector>
 
+namespace rbp {
+
 class ShelfNextFitBinPack
 {
 public:
@@ -43,3 +45,5 @@ private:
 
 	unsigned long usedSurfaceArea;
 };
+
+}

--- a/SkylineBinPack.cpp
+++ b/SkylineBinPack.cpp
@@ -15,6 +15,8 @@
 
 #include "SkylineBinPack.h"
 
+namespace rbp {
+
 using namespace std;
 
 SkylineBinPack::SkylineBinPack()
@@ -407,4 +409,6 @@ Rect SkylineBinPack::FindPositionForNewNodeMinWaste(int width, int height, int &
 float SkylineBinPack::Occupancy() const
 {
 	return (float)usedSurfaceArea / (binWidth * binHeight);
+}
+
 }

--- a/SkylineBinPack.h
+++ b/SkylineBinPack.h
@@ -12,6 +12,8 @@
 #include "Rect.h"
 #include "GuillotineBinPack.h"
 
+namespace rbp {
+
 /** Implements bin packing algorithms that use the SKYLINE data structure to store the bin contents. Uses
 	GuillotineBinPack as the waste map. */
 class SkylineBinPack
@@ -92,3 +94,5 @@ private:
 	/// Merges all skyline nodes that are at the same level.
 	void MergeSkylines();
 };
+
+}

--- a/old/RectangleBinPack.cpp
+++ b/old/RectangleBinPack.cpp
@@ -7,6 +7,8 @@
 */
 #include "RectangleBinPack.h"
 
+namespace rbp {
+
 /** Restarts the packing process, clearing all previously packed rectangles and
 	sets up a new bin of a given initial size. These bin dimensions stay fixed during
 	the whole packing process, i.e. to change the bin size, the packing must be
@@ -117,4 +119,6 @@ RectangleBinPack::Node *RectangleBinPack::Insert(RectangleBinPack::Node *node, i
 	node->width = width;
 	node->height = height;
 	return node;
+}
+
 }

--- a/old/RectangleBinPack.h
+++ b/old/RectangleBinPack.h
@@ -10,6 +10,8 @@
 
 #include "clb/Core/Ptr.h"
 
+namespace rbp {
+
 /** Performs 'discrete online rectangle packing into a rectangular bin' by maintaining 
 	a binary tree of used and free rectangles of the bin. There are several variants
 	of bin packing problems, and this packer is characterized by:
@@ -84,5 +86,7 @@ private:
 	/// Inserts a new rectangle in the subtree rooted at the given node.
 	Node *Insert(Node *node, int width, int height);
 };
+
+}
 
 #endif


### PR DESCRIPTION
- Enclose all **RectangleBinPack** classes and functions inside _rbp_ namespace to avoid conflicts with other libraries defining a **Rect** (such as MacOS Carbon)
- Move STL imports to .cpp files (speeds up compilation time and enforces better code separation)
