### PR TITLE
Add meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,20 @@
+project('RectangleBinPack', 'cpp')
+
+RectangleBinPack = static_library(
+    'RectangleBinPack',
+
+    sources : [
+        'GuillotineBinPack.cpp',
+        'MaxRectsBinPack.cpp',
+        'Rect.cpp',
+        'ShelfBinPack.cpp',
+        'ShelfNextFitBinPack.cpp',
+        'ShelfNextFitBinPack.cpp',
+        'SkylineBinPack.cpp'
+    ]
+)
+
+RectangleBinPack_dep = declare_dependency(
+    link_with : RectangleBinPack,
+    include_directories : include_directories('.')
+)


### PR DESCRIPTION
This adds a basic meson.build file. I've tested it with my own project https://github.com/tksuoran/erhe that I recently converted to use meson.