### PR TITLE
Add basic CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(RectangleBinPack VERSION "1.0.0" LANGUAGES CXX)
+
+add_library(RectangleBinPack
+    GuillotineBinPack.cpp
+    MaxRectsBinPack.cpp
+    Rect.cpp
+    ShelfBinPack.cpp
+    ShelfNextFitBinPack.cpp
+    ShelfNextFitBinPack.cpp
+    SkylineBinPack.cpp
+)
+
+target_include_directories(RectangleBinPack
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_library(RectangleBinPack::RectangleBinPack ALIAS RectangleBinPack)


### PR DESCRIPTION
This allows RectangleBinPack to be used as subproject from cmake using `add_directory()` and linking to `RectangleBinPack::RectangleBinPack`.