### PR TITLE
Fix Win32 build

### DIFF
--- a/test/MaxRectsBinPackTest.cpp
+++ b/test/MaxRectsBinPackTest.cpp
@@ -23,8 +23,6 @@ uint64_t tick()
 #if defined(WIN32)
 	LARGE_INTEGER ddwTimer;
 	BOOL success = QueryPerformanceCounter(&ddwTimer);
-	assume(success != 0);
-	MARK_UNUSED(success);
 	return ddwTimer.QuadPart;
 #elif defined(__APPLE__)
 	return mach_absolute_time();


### PR DESCRIPTION
There is no `assume()` nor `MARK_UNUSED().`

I suppose these are macros that may exists somewhere, but they are not present in this repository.