### PR TITLE
Fix build with older compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 
 project(RectangleBinPack VERSION "1.0.0" LANGUAGES CXX)
 
-add_library(RectangleBinPack
+set(TEST_PROJECT_NAME MaxRectsBinPackTest)
+
+add_library(${PROJECT_NAME}
     GuillotineBinPack.cpp
     MaxRectsBinPack.cpp
     Rect.cpp
@@ -12,16 +14,11 @@ add_library(RectangleBinPack
     SkylineBinPack.cpp
 )
 
-target_include_directories(RectangleBinPack
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
+add_library(RectangleBinPack::RectangleBinPack ALIAS ${PROJECT_NAME})
+add_executable(${TEST_PROJECT_NAME} test/MaxRectsBinPackTest.cpp MaxRectsBinPack.cpp Rect.cpp)
 
-add_library(RectangleBinPack::RectangleBinPack ALIAS RectangleBinPack)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${TEST_PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(MaxRectsBinPackTest test/MaxRectsBinPackTest.cpp MaxRectsBinPack.cpp Rect.cpp)
-
-target_include_directories(MaxRectsBinPackTest
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+target_compile_features(${TEST_PROJECT_NAME} PUBLIC cxx_std_11)


### PR DESCRIPTION
Older compilers (like GCC 4.9) need to have explicitly set C++ standard.